### PR TITLE
export `mapAsArray()` so that it is available to use

### DIFF
--- a/serializr.d.ts
+++ b/serializr.d.ts
@@ -69,6 +69,8 @@ export function list(propSchema: PropSchema): PropSchema;
 
 export function map(propSchema: PropSchema): PropSchema;
 
+export function mapAsArray(propSchema: PropSchema, keyPropertyName: string): PropSchema;
+
 export function custom(serializer: (value: any) => any, deserializer: (jsonValue: any) => any): PropSchema;
 
 export function serializeAll<T extends Function>(clazz: T): T


### PR DESCRIPTION
This PR exports `mapAsArray()` so that it is available to use.